### PR TITLE
Add a LogUpdateType column to the log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /target
 **/*.rs.bk
 hpd_violations-*.csv
-log.cache.dat
+log.pkmap.dat
 log.csv
 log.revisions.csv

--- a/README.md
+++ b/README.md
@@ -71,9 +71,7 @@ The tool also maintains the following files:
   by revision number, recording the byte offset each revision
   starts at, and how many rows it consists of.
 
-* `log.cache.dat` is a serialization of the hash map. It can
-  actually be deleted: if it's not found, the entire log will
-  be replayed to rebuild it.
+* `log.pkmap.dat` is a serialization of the hash map.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ The tool also maintains the following files:
   all revisions. This means that it contains duplicate rows for
   anything that changed between revisions.
 
+  Each row has the same schema as the original CSV file, except
+  with an additional column at the very end called
+  `LogUpdateType`: its value can be `A` to indicate that
+  the row was added, or `C` to indicate that the row was changed.
+
 * `log.revisions.csv` is essentially an index into `log.csv`
   by revision number, recording the byte offset each revision
   starts at, and how many rows it consists of.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ You can now export the changed data to stdout with:
 nycsv export 2
 ```
 
+The schema of the export is the same as the schema of the
+`log.csv` file, which is described below.
+
 ## How it works
 
 The prototype assumes that each CSV has rows that can be uniquely

--- a/src/log.rs
+++ b/src/log.rs
@@ -30,7 +30,12 @@ impl CsvLog {
     fn create_empty_logfile(&mut self, headers: &csv::ByteRecord) -> Result<(), Box<Error>> {
         let logfile = File::create(&self.filename)?;
         let mut writer = csv::Writer::from_writer(logfile);
-        writer.write_record(headers)?;
+        let mut full_headers = csv::ByteRecord::new();
+        for header in headers.iter() {
+            full_headers.push_field(header);
+        }
+        full_headers.push_field("LogUpdateType".as_bytes());
+        writer.write_record(&full_headers)?;
         writer.flush()?;
         Ok(())
     }
@@ -99,8 +104,9 @@ impl LogRevisionWriter {
         })
     }
 
-    pub fn write(&mut self, _utype: &UpdateType, record: &mut csv::ByteRecord) -> Result<(), Box<Error>> {
+    pub fn write(&mut self, utype: &UpdateType, record: &mut csv::ByteRecord) -> Result<(), Box<Error>> {
         self.rev.rows += 1;
+        record.push_field(utype.as_str().as_bytes());
         self.logfile_writer.write_record(record as &csv::ByteRecord)?;
         Ok(())
     }

--- a/src/log.rs
+++ b/src/log.rs
@@ -2,6 +2,7 @@ use std::fs::{File, metadata, OpenOptions};
 use std::path::Path;
 use std::error::Error;
 
+use update_type::UpdateType;
 
 #[derive(Serialize, Deserialize)]
 pub struct Revision {
@@ -98,9 +99,9 @@ impl LogRevisionWriter {
         })
     }
 
-    pub fn write(&mut self, record: &csv::ByteRecord) -> Result<(), Box<Error>> {
+    pub fn write(&mut self, _utype: &UpdateType, record: &mut csv::ByteRecord) -> Result<(), Box<Error>> {
         self.rev.rows += 1;
-        self.logfile_writer.write_record(record)?;
+        self.logfile_writer.write_record(record as &csv::ByteRecord)?;
         Ok(())
     }
 

--- a/src/pk_map.rs
+++ b/src/pk_map.rs
@@ -11,14 +11,12 @@ use std::time::Duration;
 use separator::Separatable;
 use pbr::ProgressBar;
 
+use update_type::UpdateType;
+
 // We're effectively using id-blake2b160. For more details, see:
 // https://tools.ietf.org/html/rfc7693
 const HASH_SIZE: usize = 20;
 
-pub enum UpdateType {
-    Added,
-    Changed
-}
 
 fn build_progress_bar(total: u64) -> ProgressBar<std::io::Stdout> {
     let mut pb = ProgressBar::new(total);
@@ -63,10 +61,10 @@ impl PkHashMap {
             if &self.temp_hash == existing_hash {
                 None
             } else {
-                Some(UpdateType::Changed)
+                Some(UpdateType::Change)
             }
         } else {
-            Some(UpdateType::Added)
+            Some(UpdateType::Add)
         };
         if result.is_some() {
             self.map.insert(pk, self.temp_hash.clone());

--- a/src/update_type.rs
+++ b/src/update_type.rs
@@ -2,3 +2,12 @@ pub enum UpdateType {
     Add,
     Change
 }
+
+impl UpdateType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            UpdateType::Add => "A",
+            UpdateType::Change => "C"
+        }
+    }
+}

--- a/src/update_type.rs
+++ b/src/update_type.rs
@@ -1,0 +1,4 @@
+pub enum UpdateType {
+    Add,
+    Change
+}


### PR DESCRIPTION
This adds a `LogUpdateType` column to the log which can be either `A` (for add) or `C` (for change).

Because it changes the schema of the log CSV to be different from that of the original, though, it was easiest to just drop support for the whole "rebuild the pkmap from the log if `log.cache.dat` doesn't exist" functionality.  It's still theoretically _possible_ to replay the log to rebuild the pkmap, it's just unlikely it'd actually be very useful, especially since the pkmap is dwarfed by the logfile itself, so there's not really any reason to ever delete it.